### PR TITLE
feat: update account and paymaster validation return format

### DIFF
--- a/packages/contracts-bedrock/test/mocks/TestAccount.sol
+++ b/packages/contracts-bedrock/test/mocks/TestAccount.sol
@@ -19,12 +19,13 @@ contract TestAccount {
     {
         (version, txHash, transaction);
         // limited to 48 bits
-        uint64 validUntil = type(uint64).max & 0xFFFFFFFFFFFF;
-        uint64 validAfter = 0;
-        validationData =
-            (bytes32(MAGIC_VALUE_SENDER) |
-            bytes32(uint256(validUntil) << (6 * 8)) |
-            bytes32(uint256(validAfter)));
+        uint48 validUntil = 0;
+        uint48 validAfter = 0;
+        validationData = bytes32(
+            uint256(uint32(MAGIC_VALUE_SENDER)) |
+            ((uint256(validUntil)) << 160) |
+            (uint256(validAfter) << (160 + 48))
+        );
     }
 
     function execute(address dest, uint256 value, bytes calldata func) external {

--- a/packages/contracts-bedrock/test/mocks/TestPaymaster.sol
+++ b/packages/contracts-bedrock/test/mocks/TestPaymaster.sol
@@ -24,11 +24,12 @@ contract TestPaymaster {
         (version, txHash, transaction);
         context = new bytes(1);
         // limited to 48 bits
-        uint64 validUntil = type(uint64).max & 0xFFFFFFFFFFFF;
-        uint64 validAfter = 0;
-        validationData =
-            (bytes32(MAGIC_VALUE_PAYMASTER) |
-            bytes32(uint256(validUntil) << (6 * 8)) |
-            bytes32(uint256(validAfter)));
+        uint48 validUntil = 0;
+        uint48 validAfter = 0;
+        validationData = bytes32(
+            uint256(uint32(MAGIC_VALUE_PAYMASTER)) |
+            ((uint256(validUntil)) << 160) |
+            (uint256(validAfter) << (160 + 48))
+        );
     }
 }


### PR DESCRIPTION
# Description

Updated the return data format of `validateTransaction` at `TestAccount.sol` and `validatePaymasterTransaction` at `TestPaymaster.sol` to fit to the changes at geth.
